### PR TITLE
Switch to using mkisofs instead of genisoimage

### DIFF
--- a/rpm/product-builder.spec
+++ b/rpm/product-builder.spec
@@ -43,7 +43,7 @@ Provides:       kiwi-packagemanager:instsource
 Requires:       build
 Requires:       inst-source-utils
 Requires:       product-builder-plugin
-Requires:       genisoimage
+Requires:       mkisofs
 Requires:       checkmedia
 %ifarch %ix86 x86_64
 Requires:       syslinux


### PR DESCRIPTION
wodim is an old and unmaintained fork of cdrtools.
We should stop using it and allow it to be removed
from the distribution in favour of the maintained
software.

With this change, I can continue to build SLE-15 images,

https://build.suse.de/project/show/home:adamm:branches:SUSE:SLE-15:GA
