### PR TITLE
Using wrong $arch on ppc64le

### DIFF
--- a/modules/KIWIIsoLinux.pm
+++ b/modules/KIWIIsoLinux.pm
@@ -158,8 +158,11 @@ sub new {
             if ($arch eq "ix86") {
                 $catalog[0] = "ix86_legacy";
             }
-            if ($arch =~ /ppc64|ppc64le/) {
+            if ($arch eq "ppc64") {
                 $catalog[0] = "ppc64_default";
+            }
+            if ($arch eq "ppc64le") {
+                $catalog[0] = "ppc64le_default";
             }
             if ($arch eq "s390") {
                 if (-d $source."/".$base{ix86}{boot}) {
@@ -415,6 +418,12 @@ sub ppc64_default {
     $para.= " -U";
     $this -> {params} = $para;
     return $this;
+}
+
+sub ppc64le_default {
+    my $this = shift;
+    my $arch = shift;
+    $this->ppc64_default($arch);
 }
 
 #==========================================


### PR DESCRIPTION
On both ppc64 and ppc64le, the same ppc64_defaults is used.
But the $arch is assumed to be embedded as part of the
catalog entry which means that ppc64le changes to ppc64 in
callBootMethods subroutine.

This fix just adds a ppc64le method that call the
ppc64 method with the same parameters and correct $arch.