### PR TITLE
Add special RPi hybrid mode

### DIFF
--- a/modules/KIWICollect.pm
+++ b/modules/KIWICollect.pm
@@ -792,6 +792,12 @@ sub mainTask {
             ) {
                 $hybridmedia = 1 ;
             }
+            my $rpihybridmedia;
+            if ( defined($this->{m_proddata}->getVar("RUN_RPIHYBRID"))
+                && $this->{m_proddata}->getVar("RUN_RPIHYBRID") eq "true"
+            ) {
+                $rpihybridmedia = 1 ;
+            }
             $iso = KIWIIsoLinux -> new(
                 $this->{m_basesubdir}->{$cd},
                 $isoname, $attr, $checkmedia, $this->{cmdL}, $this->{m_xml}
@@ -826,6 +832,13 @@ sub mainTask {
                         $this->logMsg('W', "Isohybrid call failed");
                     } else {
                         $this->logMsg('I', "Isohybrid call successful");
+                    }
+                }
+                if ($rpihybridmedia) {
+                    if(!$iso->createRPiHybrid()) {
+                        $this->logMsg('W', "Failed to create RPi Hybrid ISO");
+                    } else {
+                        $this->logMsg('I', "Successfully created RPi Hybrid ISO");
                     }
                 }
             }


### PR DESCRIPTION
One of the problems with the Raspberry Pi is that it does not contain
smart firmware - it relies on the SD card or USB storage to provide
most of the firmware smartness.

That means in order to make the iso file bootable directly for installation,
we need to provide that firmware on the ISO in a bootrom readable way.

So far that means we need provide an MBR partition table with a VFAT
partition inside that has the partition type 0xc (FAT32 LBA).

This patch adds support to create such a hybrid MBR based on the existing
hybrid MBR support. The only difference is that instead of relying on the
isohybrid tool (which also puts x86 code into the iso), we just assemble
our own MBR straight away.

Signed-off-by: Alexander Graf <agraf@suse.de>