### PR TITLE
use symlink to hashes to avoid mirror failures

### DIFF
--- a/modules/KIWICollect.pm
+++ b/modules/KIWICollect.pm
@@ -1638,6 +1638,7 @@ sub unpackMetapackages {
                             # .treeinfo for virt-installer:
                             qx(cp -a $tmp/usr/lib/skelcd/CD$_/.treeinfo $this->{m_basesubdir}->{$_}) if (-f "$tmp/usr/lib/skelcd/CD$_/.treeinfo");
                             qx(cp -a $tmp/usr/lib/skelcd/CD$_/.discinfo $this->{m_basesubdir}->{$_}) if (-f "$tmp/usr/lib/skelcd/CD$_/.discinfo");
+                            qx(cp -a $tmp/usr/lib/skelcd/CD$_/.hashed $this->{m_basesubdir}->{$_}) if (-d "$tmp/usr/lib/skelcd/CD$_/.hashed");
                             $this->logMsg('I', "Unpack CD$_");
                             $packageFound = 1;
                         } elsif (-d "$tmp/CD$_"
@@ -1654,6 +1655,7 @@ sub unpackMetapackages {
                                 # .treeinfo for virt-installer:
                                 qx(cp -a $tmp/usr/lib/skelcd/NET/.treeinfo $this->{m_basesubdir}->{$_}) if (-f "$tmp/usr/lib/skelcd/NET/.treeinfo");
                                 qx(cp -a $tmp/usr/lib/skelcd/NET/.discinfo $this->{m_basesubdir}->{$_}) if (-f "$tmp/usr/lib/skelcd/NET/.discinfo");
+                                qx(cp -a $tmp/usr/lib/skelcd/NET/.hashed $this->{m_basesubdir}->{$_}) if (-f "$tmp/usr/lib/skelcd/NET/.hashed");
                                 $this->logMsg('I', "Unpack NET");
                                 $packageFound = 1;
                             } else {


### PR DESCRIPTION
Mirrors may use rsync with the skip on same mtime feature, which would
skip files that are different in content but have the same mtime. This
results in an inconsistent mirror.

Avoid this by creating symlinks to files with the real content named
after the content hash.

When the rpm macro %clamp_mtime_to_source_date_epoch is set to Y to
enable reproducible builds, the mtime of files in the rpm will be set to
the date of the last changes entry, but build dependencies that affect
the content may be newer. This is relevant when extracting such an rpm
for a repo that is used by the installer. Some mirrors may fail to
sync to the newest content as they skipped them. This would make an
installer using that mirror fail.

Fixes: https://bugzilla.opensuse.org/show_bug.cgi?id=1148824