### PR TITLE
post process build output to reduce rsync disk io

### DIFF
--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -1,0 +1,54 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use File::Compare;
+use File::Find;
+use Time::HiRes qw(stat);
+use Time::HiRes qw(utime);
+
+sub main {
+    #if(!$ENV{BUILD_ROOT}) {
+    #    info("[I] \$BUILD_ROOT is not set\n");
+    #     exit(2);
+    #}
+    #TODO debug remove
+    print("\n\n\n");
+    find({ wanted => sub { print($_); print("\n"); } , no_chdir => 1 }, "/usr/src/packages");
+    find({ wanted => sub { print($_); print("\n"); } , no_chdir => 1 }, "/usr/lib/build");
+    print("\n\n\n");
+    #TODO
+    my $olddir = "/usr/src/packages/.build.oldpackages/KIWIROOT";
+    if(-d($olddir)) {
+        info("[I] checking for old results in $olddir if we can for each file of the build result that has the same content as the previous build use the old mtime to save rsync disk io\n");
+    } else {
+        info("[I] old packages dir does not exist, doing nothing: $olddir\n");
+        exit(0);
+    }
+    #TODO
+    my $newdir = "/usr/src/packages/KIWIROOT";
+
+    print("\n\n\n");
+    my $n = 0;
+    find({ wanted => sub {
+        my $old = $olddir . substr($_, length($newdir));
+        #TODO debug remove
+        print($_);
+        print("\n");
+        if (!-d($_) && compare($old, $_)) {
+            # index 9 is mtime
+            my $time = (stat($old))[9];
+            # this is the equivalent of the touch command
+            utime($time, $time, $_);
+            $n++;
+        }
+    } , no_chdir => 1 }, $newdir);
+    print("\n\n\n");
+    info("[I] used old mtime for $n files\n");
+}
+
+sub info {
+    print(shift)
+}
+
+main();
+

--- a/rpm/product-builder.spec
+++ b/rpm/product-builder.spec
@@ -84,6 +84,9 @@ mv %{buildroot}%{_bindir}/product-builder{.pl,}
 ln -s product-builder-sle.sh %{buildroot}%{_bindir}/product-builder
 %endif
 
+mkdir -p %{buildroot}%{_prefix}/lib/build/
+install -m 755 kiwi_post_run %{buildroot}%{_prefix}/lib/build/
+
 %files
 %dir %{_datadir}/kiwi
 %license LICENSE
@@ -92,5 +95,6 @@ ln -s product-builder-sle.sh %{buildroot}%{_bindir}/product-builder
 %{_datadir}/kiwi/modules
 %{_datadir}/kiwi/xsl
 %{_bindir}/product-builder*
+%{_prefix}/lib/build/kiwi_post_run
 
 %changelog


### PR DESCRIPTION
by using the kiwi_post_run hook to set the mtime of files that are the same as the last build to the last mtime.

If rsync is used without its --checksum argument it would skip files in error if they do not have a newer mtime. But then always using new mtimes would unecessarily use disk io to be able to skip transferring the content. This change optimizes that.

Ideally we would instead fix mirroring to consider also the file content even when the meta data is equal, either by using a sync solution that can keep that as state to not need to rehash files all the times or by accepting the disk IO cost. If we ever do we can remove this change again and set the mtime of all build output to SOURCE_DATE_EPOCH.